### PR TITLE
Implement :raise_exceptions config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master
+
+* Add new configuration option `:raise_exceptions` that can be used to enable exceptions being raised from consumers. Mostly useful for testing consumers. Defaults to `false`.
+
 ## 0.14.0
 
 * Add experimental test pool (`Msgr::TestPool`)

--- a/lib/msgr/dispatcher.rb
+++ b/lib/msgr/dispatcher.rb
@@ -7,13 +7,14 @@ module Msgr
   class Dispatcher
     include Logging
 
-    attr_reader :pool
+    attr_reader :config, :pool
 
     def initialize(config)
       config[:pool_class] ||= 'Msgr::Dispatcher::NullPool'
 
       log(:debug) { "Initialize new dispatcher (#{config[:pool_class]}: #{config})..." }
 
+      @config = config
       @pool = config[:pool_class].constantize.new config
     end
 
@@ -39,6 +40,8 @@ module Msgr
         "Dispatcher error: #{error.class.name}: #{error}\n" +
             error.backtrace.join("\n")
       end
+
+      raise error if config[:raise_exceptions]
     ensure
       if defined?(ActiveRecord) && ActiveRecord::Base.connection_pool.active_connection?
         log(:debug) { 'Release used AR connection for dispatcher thread.' }

--- a/lib/msgr/railtie.rb
+++ b/lib/msgr/railtie.rb
@@ -61,6 +61,15 @@ module Msgr
             raise ArgumentError, "Invalid value for rabbitmq config checkcredentials: \"#{cfg[:checkcredentials]}\""
         end
 
+        case cfg[:raise_exceptions]
+          when true, 'true', 'enabled'
+            cfg[:raise_exceptions] = true
+          when false, 'false', 'disabled', nil
+            cfg[:raise_exceptions] = false
+          else
+            raise ArgumentError, "Invalid value for rabbitmq config raise_exceptions: \"#{cfg[:raise_exceptions]}\""
+        end
+
         cfg[:routing_file] ||= Rails.root.join('config/msgr.rb').to_s
         cfg
       end

--- a/spec/integration/msgr/railtie_spec.rb
+++ b/spec/integration/msgr/railtie_spec.rb
@@ -35,6 +35,12 @@ describe Msgr::Railtie do
 
         it { should raise_error 'Invalid value for rabbitmq config checkcredentials: "unvalid"'}
       end
+
+      context 'with invalid raise_exceptions value' do
+        let(:settings) { {"test" => { uri: 'franz', raise_exceptions: 'unvalid'}} }
+
+        it { should raise_error 'Invalid value for rabbitmq config raise_exceptions: "unvalid"'}
+      end
     end
 
     context 'without set routes file' do
@@ -70,6 +76,15 @@ describe Msgr::Railtie do
       context '[:uri]' do
         subject { super()[:uri] }
         it { should eq 'hans' }
+      end
+    end
+
+    context 'without raise_exceptions config' do
+      let(:settings) { {"test" => { 'uri' => 'hans'}, "development" => { 'uri' => 'hans_dev'}}}
+
+      describe '[:raise_exceptions]' do
+        subject { super()[:raise_exceptions] }
+        it { should eq false }
       end
     end
   end


### PR DESCRIPTION
By default, it is set to false.

When testing consumers (i.e. when using `TestPool`), the dispatcher's
behavior of swallowing exceptions makes debugging rather hard. So, by
adding a config option to disable this behavior, we can now enjoy proper
stack traces when debugging. :-)