### PR TITLE
Replace usage of deprecated exception class

### DIFF
--- a/lib/msgr/test_pool.rb
+++ b/lib/msgr/test_pool.rb
@@ -49,7 +49,7 @@ module Msgr
           timeout -= diff
 
           if timeout <= 0
-            raise TimeoutError.new \
+            raise Timeout::Error.new \
               "Expected to receive #{count} messages but received #{received}."
           end
         end


### PR DESCRIPTION
The class `TimeoutError` is deprecated as of Ruby 2.3.

See https://github.com/thoughtbot/suspenders/pull/688 for comparison.