### PR TITLE
Explicitly catch the right errors when dumping JSON

### DIFF
--- a/lib/msgr/client.rb
+++ b/lib/msgr/client.rb
@@ -140,7 +140,7 @@ module Msgr
       begin
         payload = JSON.dump(payload)
         opts[:content_type] ||= 'application/json'
-      rescue
+      rescue JSON::JSONError
         opts[:content_type] ||= 'application/text'
       end
 


### PR DESCRIPTION
Let's be explicit about the types of errors we want to catch here.
Other runtime exceptions should bubble up and be handled in the
application layer, as they most likely signal something completely
undesirable going wrong.