### PR TITLE
Remove application/text fallback for payload

### DIFF
--- a/lib/msgr/client.rb
+++ b/lib/msgr/client.rb
@@ -137,14 +137,8 @@ module Msgr
     private
 
     def sync_publish(payload, opts)
-      begin
-        payload = JSON.dump(payload)
-        opts[:content_type] ||= 'application/json'
-      rescue JSON::JSONError
-        opts[:content_type] ||= 'application/text'
-      end
-
-      sync_publish_message payload.to_s, opts
+      opts[:content_type] ||= 'application/json'
+      sync_publish_message JSON.dump(payload).to_s, opts
     end
 
     def sync_publish_message(message, opts)


### PR DESCRIPTION
While technically a breaking change, this behavior was neither tested
nor documented. It also caused bugs and unwanted behavior in case
something went wrong during JSON serialization.

See PR #23.

If we ever want to support non-JSON payloads, that should probably be
made explicit, e.g. by calling a different method, when an event is
being published.