### PR TITLE
msgr:purge - Rake task for purging all known queues

### DIFF
--- a/lib/msgr/channel.rb
+++ b/lib/msgr/channel.rb
@@ -28,8 +28,8 @@ module Msgr
       end
     end
 
-    def queue(name)
-      @channel.queue(prefix(name), durable: true).tap do |queue|
+    def queue(name, **opts)
+      @channel.queue(prefix(name), durable: true, **opts).tap do |queue|
         log(:debug) do
           "Create queue #{queue.name} (durable: #{queue.durable?}, " \
           "auto_delete: #{queue.auto_delete?})"

--- a/lib/msgr/client.rb
+++ b/lib/msgr/client.rb
@@ -101,6 +101,15 @@ module Msgr
       end
     end
 
+    ##
+    # Purge all queues known to Msgr, if they exist.
+    #
+    def drain
+      @routes.each do |route|
+        connection.purge_queue(route.name)
+      end
+    end
+
     def publish(payload, opts = {})
       mutex.synchronize do
         check_process!

--- a/lib/msgr/connection.rb
+++ b/lib/msgr/connection.rb
@@ -70,6 +70,16 @@ module Msgr
       bindings.each {|b| b.purge(**kwargs) }
     end
 
+    def purge_queue(name)
+      # Creating the queue in passive mode ensures that queues that do not exist
+      # won't be created just to purge them.
+      # That requires creating a new channel every time, as exceptions (on
+      # missing queues) invalidate the channel.
+      channel.queue(name, passive: true).purge
+    rescue Bunny::NotFound
+      nil
+    end
+
     def bindings
       @bindings ||= []
     end

--- a/lib/msgr/railtie.rb
+++ b/lib/msgr/railtie.rb
@@ -25,6 +25,10 @@ module Msgr
       end
     end
 
+    rake_tasks do
+      load File.expand_path('tasks/msgr/drain.rake', __dir__)
+    end
+
     class << self
       def load(config)
         config = DEFAULT_OPTIONS.merge(config)

--- a/lib/msgr/tasks/msgr/drain.rake
+++ b/lib/msgr/tasks/msgr/drain.rake
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+namespace :msgr do
+  desc 'Drain all known queues'
+  task drain: :environment do
+    client = Msgr.client
+
+    client.connect
+    client.drain
+  end
+end


### PR DESCRIPTION
As discussed, this implements a Rake task (when installed in a Rails context) for purging (i.e. emptying) all queues configured in Msgr's routing file - but only the ones that exist.