### PR TITLE
Fix draining routes

### DIFF
--- a/lib/msgr/client.rb
+++ b/lib/msgr/client.rb
@@ -21,7 +21,7 @@ module Msgr
       @config.merge! config.symbolize_keys
 
       @mutex  = ::Mutex.new
-      @routes = Routes.new
+      @routes = load_routes
       @pid ||= ::Process.pid
 
       log(:debug) { "Created new client on process ##{@pid}..." }
@@ -59,8 +59,6 @@ module Msgr
 
         log(:debug) { "Start on #{uri}..." }
 
-        @routes << config[:routing_file] if config[:routing_file].present?
-        @routes.reload
         connection.bind(@routes)
       end
     end
@@ -191,6 +189,13 @@ module Msgr
       config[:ssl]   ||= uri.scheme.casecmp('amqps').zero?
 
       config
+    end
+
+    def load_routes
+      Routes.new.tap do |routes|
+        routes << config[:routing_file] if config[:routing_file].present?
+        routes.reload
+      end
     end
   end
 end

--- a/spec/fixtures/msgr_routes_test_drain.rb
+++ b/spec/fixtures/msgr_routes_test_drain.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+route 'abc', to: 'consumer1#action1'
+route 'def', to: 'consumer1#action2'
+route 'ghi', to: 'consumer2#action1'

--- a/spec/unit/msgr/client_spec.rb
+++ b/spec/unit/msgr/client_spec.rb
@@ -60,16 +60,11 @@ describe Msgr::Client do
   describe 'drain' do
     subject(:drain) { client.drain }
 
+    let(:config) { {routing_file: 'spec/fixtures/msgr_routes_test_drain.rb'} }
     let(:channel_stub) { instance_double('Msgr::Channel', prefetch: true) }
     let(:queue_stub) { instance_double('Bunny::Queue', purge: true) }
 
     before do
-      client.routes.configure do
-        route 'abc', to: 'consumer1#action1'
-        route 'def', to: 'consumer1#action2'
-        route 'ghi', to: 'consumer2#action1'
-      end
-
       allow(Msgr::Channel).to receive(:new).and_return(channel_stub)
       allow(channel_stub).to receive(:queue).and_return(queue_stub).at_most(3).times
     end


### PR DESCRIPTION
Because we only read the routes from our routing file when connecting to
RabbitMQ for consumption, we did not have any routes registered when
trying to drain them.

Loading the routing file immediately when initializing the client
resolves the problem. The existing tests were adapted to catch this bug.