### PR TITLE
Support namespaced consumer names

### DIFF
--- a/lib/msgr/route.rb
+++ b/lib/msgr/route.rb
@@ -4,7 +4,7 @@ module Msgr
   class Route
     attr_reader :consumer, :action, :opts
 
-    MATCH_REGEXP = /\A(?<consumer>\w+)#(?<action>\w+)\z/.freeze
+    MATCH_REGEXP = %r{\A(?<consumer>(?:\w+/)*\w+)#(?<action>\w+)\z}.freeze
     def initialize(key, opts = {})
       @opts = opts
       raise ArgumentError.new 'Missing `to` options.' unless @opts[:to]
@@ -16,7 +16,7 @@ module Msgr
       unless result
         raise ArgumentError.new \
           "Invalid consumer format: #{opts[:to].strip.to_s.inspect}. " \
-          'Must be `consumer_class#action`.'
+          'Must be `name/space/consumer_class#action`.'
       end
 
       @consumer = "#{result[:consumer].camelize}Consumer"

--- a/spec/unit/msgr/route_spec.rb
+++ b/spec/unit/msgr/route_spec.rb
@@ -34,6 +34,12 @@ describe Msgr::Route do
         described_class.new routing_key, to: 'abc'
       end.to raise_error ArgumentError, /invalid consumer format/i
     end
+
+    it 'allows namespaces in consumer' do
+      expect do
+        described_class.new routing_key, to: 'abc/def#ghi'
+      end.not_to raise_error
+    end
   end
 
   describe '#consumer' do
@@ -44,8 +50,16 @@ describe Msgr::Route do
     context 'with underscore consumer name' do
       let(:options) { super().merge to: 'test_resource_foo#index' }
 
-      it 'returns camelized method name' do
+      it 'returns camelized class name' do
         expect(route.consumer).to eq 'TestResourceFooConsumer'
+      end
+    end
+
+    context 'with nested namespace in consumer name' do
+      let(:options) { super().merge to: 'nested/namespace/foo#index' }
+
+      it 'returns fully classified, classified class name' do
+        expect(route.consumer).to eq 'Nested::Namespace::FooConsumer'
       end
     end
   end


### PR DESCRIPTION
Just like Rails does for controllers, this adds support for
routing to consumer classes nested within modules.

Fixes #48.