### PR TITLE
chore!: Drop support Ruby <3.2 and Rails <7.2 (EOL or old)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,34 +11,10 @@ jobs:
           - "3.4"
           - "3.3"
           - "3.2"
-          - "3.1"
-          - "3.0"
-          - "2.7"
         gemfile:
           - rails_8.0.gemfile
           - rails_7.2.gemfile
           - rails_7.1.gemfile
-          - rails_7.0.gemfile
-          - rails_6.1.gemfile
-        exclude:
-          - gemfile: rails_8.0.gemfile
-            ruby: "3.1"
-          - gemfile: rails_8.0.gemfile
-            ruby: "3.0"
-          - gemfile: rails_8.0.gemfile
-            ruby: "2.7"
-          - gemfile: rails_7.2.gemfile
-            ruby: "3.0"
-          - gemfile: rails_7.2.gemfile
-            ruby: "2.7"
-          - gemfile: rails_7.1.gemfile
-            ruby: "3.0"
-          - gemfile: rails_7.1.gemfile
-            ruby: "2.7"
-          - gemfile: rails_7.0.gemfile
-            ruby: "3.4"
-          - gemfile: rails_6.1.gemfile
-            ruby: "3.4"
       fail-fast: False
 
     services:
@@ -92,7 +68,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.4"
           bundler-cache: true
 
       - name: Run rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
   rubocop-config: default.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: "3.2"
   SuggestExtensions: False
   Exclude:
     - gemfiles/**/*

--- a/Appraisals
+++ b/Appraisals
@@ -2,16 +2,6 @@
 
 # vim: ft=ruby
 
-appraise 'rails-6.1' do
-  gem 'rails', '~> 6.1.0'
-  gem 'sqlite3', '~> 1.4'
-end
-
-appraise 'rails-7.0' do
-  gem 'rails', '~> 7.0.0'
-  gem 'sqlite3', '~> 1.4'
-end
-
 appraise 'rails-7.1' do
   gem 'rails', '~> 7.1.0'
   gem 'sqlite3', '~> 2.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Support for Ruby 3.4 and Rails 8.0
 
+### Changed
+
+- Require Ruby 3.2+ and Rails 7.1+
+
 ## [1.6.1] - 2024-10-04
 
 ### Fixed

--- a/lib/msgr.rb
+++ b/lib/msgr.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
-# Require logger before active_support
-# (https://github.com/rails/rails/pull/54264)
 require 'logger'
 
 require 'msgr/version'
+
 require 'active_support'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/module/delegation'

--- a/lib/msgr/dispatcher.rb
+++ b/lib/msgr/dispatcher.rb
@@ -63,8 +63,8 @@ module Msgr
     class NullPool
       def initialize(*); end
 
-      def post(*args)
-        yield(*args)
+      def post(*)
+        yield(*)
       end
     end
   end

--- a/lib/msgr/route.rb
+++ b/lib/msgr/route.rb
@@ -4,7 +4,7 @@ module Msgr
   class Route
     attr_reader :consumer, :action, :opts
 
-    MATCH_REGEXP = %r{\A(?<consumer>(?:\w+/)*\w+)#(?<action>\w+)\z}.freeze
+    MATCH_REGEXP = %r{\A(?<consumer>(?:\w+/)*\w+)#(?<action>\w+)\z}
     def initialize(key, opts = {})
       @opts = opts
       raise ArgumentError.new 'Missing `to` options.' unless @opts[:to]

--- a/lib/msgr/test_pool.rb
+++ b/lib/msgr/test_pool.rb
@@ -60,8 +60,8 @@ module Msgr
         @instance ||= super # rubocop:disable Naming/MemoizedInstanceVariableName
       end
 
-      def run(**kwargs)
-        new.run(**kwargs)
+      def run(**)
+        new.run(**)
       end
 
       def clear

--- a/msgr.gemspec
+++ b/msgr.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) {|f| File.basename(f) }
   spec.require_paths = %w[lib]
 
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 3.2'
 
-  spec.add_dependency 'activesupport'
+  spec.add_dependency 'activesupport', '>= 7.1'
   spec.add_dependency 'bunny', '>= 1.4', '< 3.0'
   spec.add_dependency 'logger'
 end

--- a/scripts/simple_test.rb
+++ b/scripts/simple_test.rb
@@ -22,8 +22,8 @@ end
 class NullPool
   def initialize(*); end
 
-  def post(*args)
-    yield(*args)
+  def post(*)
+    yield(*)
   end
 end
 

--- a/spec/integration/dummy/config/application.rb
+++ b/spec/integration/dummy/config/application.rb
@@ -2,8 +2,6 @@
 
 require File.expand_path('boot', __dir__)
 
-require 'logger'
-
 require 'rails/all'
 
 Bundler.require(*Rails.groups)

--- a/spec/integration/spec_helper.rb
+++ b/spec/integration/spec_helper.rb
@@ -24,7 +24,7 @@ require 'rspec/rails'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
-Dir[File.expand_path('support/**/*.rb', __dir__)].sort.each {|f| require f }
+Dir[File.expand_path('support/**/*.rb', __dir__)].each {|f| require f }
 
 if ActiveRecord::Migration.respond_to?(:check_all_pending!)
   ActiveRecord::Migration.check_all_pending!

--- a/spec/unit/spec_helper.rb
+++ b/spec/unit/spec_helper.rb
@@ -19,7 +19,7 @@ end
 
 require 'msgr'
 
-Dir[File.expand_path('support/**/*.rb', __dir__)].sort.each {|f| require f }
+Dir[File.expand_path('support/**/*.rb', __dir__)].each {|f| require f }
 
 RSpec.configure do |config|
   config.order = 'random'


### PR DESCRIPTION
* Require Ruby 3.2+ 
* Require Rails 7.2+ 
* Update gemspec and rubocop targets